### PR TITLE
Remove some of the algorithms that fail the ci testing.

### DIFF
--- a/test/client_integration/rdas-atmosphere-templates.yaml
+++ b/test/client_integration/rdas-atmosphere-templates.yaml
@@ -3,11 +3,11 @@
 supported_algorithms:
 - 3dvar
 - hofx3d
-- hofx4d
-- local_ensemble_da
+#- hofx4d
+#- local_ensemble_da
 # Local algorithms
-- fv3jedi_fv3inc_lgetkf
-- fv3jedi_fv3inc_variational
+#- fv3jedi_fv3inc_lgetkf
+#- fv3jedi_fv3inc_variational
 
 # This is overwritten in the testing but allows command line test of jcb
 #algorithm: fv3jedi_fv3inc_variational


### PR DESCRIPTION
This PR is meant to fix the failing CI tests in https://github.com/NOAA-EMC/jcb/pull/30.

The `supported_algorithms`: hofx4d, and locaal_ensemble_da were not working. Additionally, the local algorithms fv3jedi_fv3inc_lgetkf and fv3jedi_fv3inc_variational have not yet been jinja-fied and more testing will be needed.